### PR TITLE
Use rclcpp::QoS objects for service and topic QoS defaults

### DIFF
--- a/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/bt_service_node.hpp
@@ -144,7 +144,7 @@ protected:
   {
     ServiceClientInstance(std::shared_ptr<rclcpp::Node> node,
                           const std::string& service_name,
-                          const rmw_qos_profile_t& qos_profile);
+                          const rclcpp::QoS& qos);
 
     ServiceClientPtr service_client;
     rclcpp::CallbackGroup::SharedPtr callback_group;
@@ -189,7 +189,7 @@ protected:
 
   std::weak_ptr<rclcpp::Node> node_;
   std::string service_name_;
-  rmw_qos_profile_t qos_profile_;
+  rclcpp::QoS qos_;
   bool service_name_should_be_checked_ = false;
   const std::chrono::milliseconds service_timeout_;
   const std::chrono::milliseconds wait_for_service_timeout_;
@@ -213,13 +213,13 @@ private:
 template <class T>
 inline RosServiceNode<T>::ServiceClientInstance::ServiceClientInstance(
     std::shared_ptr<rclcpp::Node> node, const std::string& service_name,
-    const rmw_qos_profile_t& qos_profile)
+    const rclcpp::QoS& qos)
 {
   callback_group =
       node->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
   callback_executor.add_callback_group(callback_group, node->get_node_base_interface());
 
-  service_client = node->create_client<T>(service_name, qos_profile, callback_group);
+  service_client = node->create_client<T>(service_name, qos, callback_group);
 }
 
 template <class T>
@@ -230,7 +230,7 @@ inline RosServiceNode<T>::RosServiceNode(const std::string& instance_name,
   , node_(params.nh)
   , service_timeout_(params.server_timeout)
   , wait_for_service_timeout_(params.wait_for_server_timeout)
-  , qos_profile_(params.service_qos_profile)
+  , qos_(params.service_qos)
 {
   // check port remapping
   auto portIt = config().input_ports.find("service_name");
@@ -278,7 +278,7 @@ inline bool RosServiceNode<T>::createClient(const std::string& service_name)
   if(it == registry.end() || it->second.expired())
   {
     srv_instance_ =
-        std::make_shared<ServiceClientInstance>(node, service_name, qos_profile_);
+        std::make_shared<ServiceClientInstance>(node, service_name, qos_);
     registry.insert({ client_key, srv_instance_ });
 
     RCLCPP_INFO(logger(), "Node [%s] created service client [%s]", name().c_str(),

--- a/behaviortree_ros2/include/behaviortree_ros2/ros_node_params.hpp
+++ b/behaviortree_ros2/include/behaviortree_ros2/ros_node_params.hpp
@@ -39,9 +39,8 @@ struct RosNodeParams
   // Default qos configuration for actions, services and topics
   rcl_action_client_options_t action_client_options =
       rcl_action_client_get_default_options();
-  rmw_qos_profile_t service_qos_profile = rmw_qos_profile_services_default;
-  rclcpp::QoS topic_qos =
-      rclcpp::QoS(rclcpp::QoSInitialization::from_rmw(rmw_qos_profile_default));
+  rclcpp::QoS service_qos = rclcpp::ServicesQoS();
+  rclcpp::QoS topic_qos = rclcpp::SystemDefaultsQoS();
 
   // parameters used only by service client and action clients
 


### PR DESCRIPTION
Another small fix: address compiler warning about deprecated call to `create_client` with `rmw_qos_profile_t`
`service_qos` type changed to match